### PR TITLE
Atualização da documentação

### DIFF
--- a/docker_basics/README.md
+++ b/docker_basics/README.md
@@ -14,7 +14,7 @@ O estado inicial está na branch _main_, enquanto a resolução padrão está na
 
 No estado inicial do Dojo você consegue verificar se tudo está OK para começar usando o comando ```flask run```
 
-Ele vai subir a aplicação no seu computador. Se tudo estiver OK, ao acessar no seu navegador o endereço ```http://localhost:8042/guia/quote``` você deverá ver a mensagem ```NÃO ENTRE EM PÂNICO```
+Ele vai subir a aplicação no seu computador. Se tudo estiver OK, ao acessar no seu navegador o endereço ```http://localhost:5000/guia/quote``` você deverá ver a mensagem ```NÃO ENTRE EM PÂNICO```
 
 ## O desafio
 


### PR DESCRIPTION
Lula. Como aqui não funcionou o localhost na porta `8042` e sim na `5000`, chequei na [documentação do flask](https://flask.palletsprojects.com/en/3.0.x/server/) e padrão é a `5000`